### PR TITLE
Add GitHub Actions Workflow to Publish Python Package to PyPI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,34 @@
+name: Publish Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.12'  # Replace with your Python version
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build package
+      run: |
+        python setup.py sdist bdist_wheel
+
+    - name: Publish package to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        twine upload dist/*


### PR DESCRIPTION
### Pull Request Description

**Title: Add GitHub Actions Workflow to Publish Python Package to PyPI**

**Description:**
This pull request adds a GitHub Actions workflow to automate the process of building and publishing the `dirmap` Python package to PyPI upon the creation of a new release. This ensures that the latest version of the package is always available on PyPI without manual intervention.

**Changes Made:**

1. **New Workflow File:**
   - Added `.github/workflows/publish.yml` to define the workflow for publishing to PyPI.

2. **Workflow Steps:**
   - **Checkout code**: Uses `actions/checkout@v2` to check out the repository code.
   - **Set up Python**: Uses `actions/setup-python@v2` to set up the specified Python version.
   - **Install dependencies**: Installs the necessary dependencies including `setuptools`, `wheel`, and `twine`.
   - **Build package**: Builds the source and wheel distributions of the package.
   - **Publish package to PyPI**: Uses `twine` to upload the built distributions to PyPI.

**Workflow Configuration:**

**File: `.github/workflows/publish.yml`**

**Instructions for Setting Up PyPI API Token:**

1. **Generate PyPI API Token**:
   - Log in to your PyPI account.
   - Navigate to your account settings and create a new API token.

2. **Add PyPI API Token to GitHub Secrets**:
   - Go to your GitHub repository.
   - Navigate to "Settings" > "Secrets and variables" > "Actions".
   - Add a new secret with the name `PYPI_API_TOKEN` and paste the API token.

**Notes:**
- This workflow triggers automatically when a new release is published on GitHub.
- Ensure that the Python version specified in the workflow matches the version used in your project.

This automation simplifies the release process, ensuring that the latest package is always available to users on PyPI. It reduces the potential for human error and ensures consistency in the deployment process.